### PR TITLE
feat: Add selected tab styling with color change

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,13 @@ function openTab(tabName) {
         tabContent[i].style.display = "none";
     }
 
+    const tabLinks = document.getElementsByClassName("tablink");
+    for (let i = 0; i < tabLinks.length; i++) {
+        tabLinks[i].classList.remove("selected");
+    }
+
     document.getElementById(tabName).style.display = "block";
+    event.currentTarget.classList.add("selected");
 }
 
 function checkQuiz() {

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,11 @@ body {
     cursor: pointer;
 }
 
+.tablink.selected {
+    background-color: #007bff; /* Change to the color of your choice */
+    color: #fff; /* Change to the color that provides good contrast with the background */
+}
+
 .tabcontent {
     display: none;
     padding: 10px;


### PR DESCRIPTION
In this commit, I added a new CSS style to the tabbed interface to indicate the selected tab. When a tab is clicked, it now changes its background color to #007bff, providing a visual cue that it is currently active. Additionally, the text color is set to white for better contrast. This change improves the user experience and helps users easily identify the active tab.

Files modified:
- styles.css
- script.js

Screenshots:

Before:
We have no indication of which tab is selected
<img width="1512" alt="image" src="https://github.com/zero2sudo/learn-git/assets/99109449/b1788873-c7f8-42a5-b295-efe4cc340057">

After:
Selected tab is highlighted with #007bff
<img width="1512" alt="image" src="https://github.com/zero2sudo/learn-git/assets/99109449/f3369c6e-886c-4aca-b813-e7ee7aff7e69">


