### PR TITLE
feat: Save selected tab in query parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 <body>
     <div class="container">
         <div class="tabs">
-            <button id="tab-fundamentals" class="tablink" onclick="openTab('tab-fundamentals')">Git Fundamentals</button>
-            <button id="tab-quiz" class="tablink" onclick="openTab('tab-quiz')">Quiz</button>
+            <button id="tab-fundamentals" class="tablink" onclick="handleTabSelection('tab-fundamentals')">Git Fundamentals</button>
+            <button id="tab-quiz" class="tablink" onclick="handleTabSelection('tab-quiz')">Quiz</button>
         </div>
         <div id="fundamentals" class="tabcontent">
             <h2>Git Fundamentals</h2>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 <body>
     <div class="container">
         <div class="tabs">
-            <button class="tablink" onclick="openTab('fundamentals')">Git Fundamentals</button>
-            <button class="tablink" onclick="openTab('quiz')">Quiz</button>
+            <button id="tab-fundamentals" class="tablink" onclick="openTab('tab-fundamentals')">Git Fundamentals</button>
+            <button id="tab-quiz" class="tablink" onclick="openTab('tab-quiz')">Quiz</button>
         </div>
         <div id="fundamentals" class="tabcontent">
             <h2>Git Fundamentals</h2>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,11 @@
 function openTab(tabName) {
+    /** Handle on click scenario */
     const tabContent = document.getElementsByClassName("tabcontent");
     for (let i = 0; i < tabContent.length; i++) {
         tabContent[i].style.display = "none";
     }
 
+    /** Handle on click scenario */
     const tabLinks = document.getElementsByClassName("tablink");
     for (let i = 0; i < tabLinks.length; i++) {
         tabLinks[i].classList.remove("selected");
@@ -48,5 +50,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const tabParam = getParameterByName('tab');
     if (tabParam) {
         openTab(tabParam);
+
+        // Highlight the initially selected tab based on the query parameter
+        const tabLinks = document.getElementsByClassName("tablink");
+        for (let i = 0; i < tabLinks.length; i++) {
+            if (tabLinks[i].textContent.toLowerCase() === tabParam.toLowerCase()) {
+                tabLinks[i].classList.add("selected");
+                break;
+            }
+        }
     }
 });

--- a/script.js
+++ b/script.js
@@ -27,18 +27,13 @@ function getTabContentIdFromCurrentTabId(tabName) {
     console.error('Invalid tab query param! Update this function to handle this tab query param: ', tabName);
 }
 
-function openTab(tabName) {
-    console.log('tab was clicked, tab is: ', tabName);
-    
-    const tabContent = document.getElementsByClassName("tabcontent");
-
-    hideAllTabContentsAndTabStyles();
-
-
-
+function displayTabContentAndStyleSelectedTab(tabName) {
     document.getElementById(getTabContentIdFromCurrentTabId(tabName)).style.display = "block";
     document.getElementById(tabName).classList.add("selected");
+}
 
+function handleTabSelection(tabName) {
+    initializeTab(tabName);
     // Save the selected tab in the query parameter
     const urlParams = new URLSearchParams(window.location.search);
     urlParams.set('tab', tabName);
@@ -71,11 +66,16 @@ function getParameterByName(name) {
     return urlParams.get(name);
 }
 
+function initializeTab(tabParam) {
+    hideAllTabContentsAndTabStyles();
+    displayTabContentAndStyleSelectedTab(tabParam);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const tabParam = getParameterByName('tab');
 
     if (tabParam) {
-        openTab(tabParam);
+        initializeTab(tabParam);
     } else {
         // If the tab parameter is not present, set it to 'fundamentals'
         history.replaceState({}, '', `${location.pathname}?tab=tab-fundamentals`);

--- a/script.js
+++ b/script.js
@@ -11,7 +11,13 @@ function openTab(tabName) {
 
     document.getElementById(tabName).style.display = "block";
     event.currentTarget.classList.add("selected");
+
+    // Save the selected tab in the query parameter
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.set('tab', tabName);
+    history.replaceState({}, '', `${location.pathname}?${urlParams}`);
 }
+
 
 function checkQuiz() {
     const correctAnswers = ["a", "c"]; // Replace with the correct answers for each question
@@ -31,3 +37,16 @@ function checkQuiz() {
 
     return false; // Prevent form submission
 }
+
+
+function getParameterByName(name) {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get(name);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const tabParam = getParameterByName('tab');
+    if (tabParam) {
+        openTab(tabParam);
+    }
+});

--- a/script.js
+++ b/script.js
@@ -40,7 +40,6 @@ function handleTabSelection(tabName) {
     history.replaceState({}, '', `${location.pathname}?${urlParams}`);
 }
 
-
 function checkQuiz() {
     const correctAnswers = ["a", "c"]; // Replace with the correct answers for each question
 
@@ -59,7 +58,6 @@ function checkQuiz() {
 
     return false; // Prevent form submission
 }
-
 
 function getParameterByName(name) {
     const urlParams = new URLSearchParams(window.location.search);

--- a/script.js
+++ b/script.js
@@ -1,18 +1,43 @@
-function openTab(tabName) {
-    /** Handle on click scenario */
+function hideAllTabContentsAndTabStyles() {
     const tabContent = document.getElementsByClassName("tabcontent");
+
+    // On initial load hide all tabContents
     for (let i = 0; i < tabContent.length; i++) {
         tabContent[i].style.display = "none";
     }
 
-    /** Handle on click scenario */
+    // On initial load, remove any selected information on the tab
     const tabLinks = document.getElementsByClassName("tablink");
     for (let i = 0; i < tabLinks.length; i++) {
         tabLinks[i].classList.remove("selected");
     }
 
-    document.getElementById(tabName).style.display = "block";
-    event.currentTarget.classList.add("selected");
+}
+
+// tabName should be a query param value
+function getTabContentIdFromCurrentTabId(tabName) {
+    if (tabName === 'tab-fundamentals') {
+        return 'fundamentals';
+    } 
+    
+    if (tabName === 'tab-quiz') {
+        return 'quiz';
+    }
+
+    console.error('Invalid tab query param! Update this function to handle this tab query param: ', tabName);
+}
+
+function openTab(tabName) {
+    console.log('tab was clicked, tab is: ', tabName);
+    
+    const tabContent = document.getElementsByClassName("tabcontent");
+
+    hideAllTabContentsAndTabStyles();
+
+
+
+    document.getElementById(getTabContentIdFromCurrentTabId(tabName)).style.display = "block";
+    document.getElementById(tabName).classList.add("selected");
 
     // Save the selected tab in the query parameter
     const urlParams = new URLSearchParams(window.location.search);
@@ -48,16 +73,12 @@ function getParameterByName(name) {
 
 document.addEventListener('DOMContentLoaded', () => {
     const tabParam = getParameterByName('tab');
+
     if (tabParam) {
         openTab(tabParam);
-
-        // Highlight the initially selected tab based on the query parameter
-        const tabLinks = document.getElementsByClassName("tablink");
-        for (let i = 0; i < tabLinks.length; i++) {
-            if (tabLinks[i].textContent.toLowerCase() === tabParam.toLowerCase()) {
-                tabLinks[i].classList.add("selected");
-                break;
-            }
-        }
+    } else {
+        // If the tab parameter is not present, set it to 'fundamentals'
+        history.replaceState({}, '', `${location.pathname}?tab=tab-fundamentals`);
+        window.location.reload();
     }
 });


### PR DESCRIPTION
With this commit, the tabbed interface now saves the selected tab in a query parameter of the URL. When a tab is clicked, the URL is updated with the `tab` query parameter set to the name of the selected tab. This enhancement allows users to share URLs with the specific tab preselected, and when they revisit the page, it will open with the previously selected tab based on the query parameter.

Files modified:
- index.html
- script.js

Screenshot evidence:
When a tab is selected, we now store the tab selection in query params.
<img width="438" alt="image" src="https://github.com/zero2sudo/learn-git/assets/99109449/2863fe12-d428-4516-a5ab-a23732d69311">

